### PR TITLE
Add calendar and correct typos

### DIFF
--- a/docs/Onboarding/accessing-hpc.md
+++ b/docs/Onboarding/accessing-hpc.md
@@ -6,7 +6,9 @@ nav_order: 4
 ---
 
 ## Antivirus
-Data security is of utmost importance. All members of the NDCLab are expected to install, and maintain up-to-date, an appropriate antivirus program on their computer prior to connecting the the FIU HPC. If you are unsure of which antivirus program to install, please visit https://www.cnet.com/ and choose a FREE antivirus program that has recieved favorable reviews.
+Data security is of utmost importance. All members of the NDCLab are expected to install, and maintain up-to-date, an appropriate antivirus program on their computer prior to connecting the the FIU HPC.
+
+If you are unsure of which antivirus program to install, visit [CNET](https://www.cnet.com/), which has reviews for various options. Select an antivirus program that has received favorable reviews from CNET. Free programs are encouraged, provided that the reviews are favorable. Note that FIU recommend AVG for Mac.
 
 ## Gaining Access
 All members of the NDCLab receive access to the lab folder on the FIU HPC. The lab manager, who is responsible for coordinating your access request, will need your FIU e-mail and Panther ID.

--- a/docs/Onboarding/ccf-access.md
+++ b/docs/Onboarding/ccf-access.md
@@ -57,9 +57,11 @@ A link at the bottom of this e-mail allows you to:
 
 ## Step 5: Data Services
 
-The creation of the incoming lab member's AD account triggers an actionable e-mail from the CCF that includes completing a separate HIPAA training course. This message is sent to the e-mail associated with the new AD account. Note that if you already had an FIU AD account from a prior internship or employment, then the CCF may not properly trigger an actionable e-mail from the CCF, and, the lab manager will need to follow-up with the CCF to move the onboarding process forward. If you have a prior FIU email adress with no numbers in it (from a previous volunteer or paid postion at FIU) it is important that you communicate this to the lab manager.
+The creation of the incoming lab member's AD account triggers an actionable e-mail from the CCF that includes completing a separate HIPAA training course. This message is sent to the e-mail associated with the new AD account.
 
-It is important that you complete this training under the new login that you have been assigned (your AD account), not your student login. Once complete, click the link in the e-mail from the CCF to upload your certificate.
+(Note: if you already had an FIU AD account from a prior internship or employment, then the CCF may not properly trigger an actionable e-mail and the lab manager will need to follow-up with the CCF directly in order to move the onboarding process forward. If you previously had an FIU e-mail address with no numbers in it, it is important that you communicate this to the lab manager.)
+
+The HIPAA training course must be completed under your AD account (that is, the new login that you have just been assigned or, if you previously had an FIU internship/employment, your re-activated login). Do not complete the HIPAA training under your student login. Once complete, click the link in the e-mail from the CCF to upload your certificate.
 
 ![hipaa-requirement](https://raw.githubusercontent.com/NDCLab/wiki/main/docs/_assets/onboarding/hipaa-requirement.png)
 

--- a/docs/Onboarding/overview.md
+++ b/docs/Onboarding/overview.md
@@ -12,8 +12,9 @@ Following a successful interview, a new lab member will be invited to join the i
 All lab members are given access to the following:
 1. **Slack:** The lab manager will send the incoming member an invite to join the [NDCLab Slack workspace](https://ndclab.github.io/wiki/docs/Onboarding/slack-setup.html) and ensure that they are invited to the appropriate channels.
 2. **Lab meeting:** The lab manager will send the incoming member an invite to join the weekly lab meeting, held on Zoom.
-3. **Google Drive:** The lab manager will send the incoming member an invite to access the lab's Google Drive folder.
-4. **GitHub:** New lab members should work through the ["Get with Git" mini-training program](https://ndclab.github.io/wiki/docs/Onboarding/accessing-hpc.html) so that they are comfortable working with the lab's GitHub repositories. This is self-paced and can be started at any time.
+3. **Lab calendar:** The lab manager will grant the incoming member access to view the [lab calendar](https://ndclab.github.io/wiki/docs/around-the-lab/lab-meeting.html)
+4. **Google Drive:** The lab manager will send the incoming member an invite to access the lab's Google Drive folder.
+5. **GitHub:** New lab members should work through the ["Get with Git" mini-training program](https://ndclab.github.io/wiki/docs/Onboarding/accessing-hpc.html) so that they are comfortable working with the lab's GitHub repositories. This is self-paced and can be started at any time.
 
 ## HPC Access
 The lab manager will request HPC access for the incoming lab member. The incoming lab member should schedule a time to attend the [HPC Onboarding training](https://ndclab.github.io/wiki/docs/Onboarding/accessing-hpc.html), currently held every Tuesday from 11 am - 12 noon EST.

--- a/docs/around-the-lab/lab-meeting.md
+++ b/docs/around-the-lab/lab-meeting.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: Lab Meetings
+parent: Around the Lab
+nav_order: 3
+---
+
+
+## Lab Calendar
+
+The lab maintains a shared Google calendar, to which lab members are granted access during [formal onboarding](https://ndclab.github.io/wiki/docs/Onboarding/overview.html). This calendar provide a broad view into ongoing lab activities.
+
+## Weekly Lab Meeting
+
+A one-hour lab meeting is held weekly. All lab members are encouraged to attend, but attendance is not mandatory for junior members. All lab meetings are recorded so that they can be attended asynchronously.
+
+* Agendas are posted the week prior on GitHub.
+* The lab manager messages on the Slack #general channel, starting with: `Lab Meeting | yyyy-mm-dd`; this post includes a link to the GitHub agenda.
+* Following the meeting, the lab manager adds meeting notes and a link to the meeting recording on the same thread.
+* The lab manager's posts for the most recent lab meeting and the next upcoming meeting are always pinned to the #general channel in Slack.
+* Older posts can be found by searching within Slack:
+```
+lab meeting in:#general
+```
+
+## Other Meetings
+
+The lab director, lab manager, lab technician, and project leads may schedule activities on the lab calendar. Only required attendees should receive individual invites to such meetings, so that they also appear on the individual's personal calendar. However, since all lab members have access to the calendar, they can see the existence of any upcoming meeting and request to join in, if so desired.

--- a/docs/around-the-lab/report-concerns.md
+++ b/docs/around-the-lab/report-concerns.md
@@ -2,7 +2,7 @@
 layout: default
 title: Reporting Concerns
 parent: Around the Lab
-nav_order: 3
+nav_order: 4
 ---
 
 ### Contents

--- a/docs/around-the-lab/roles-expectations.md
+++ b/docs/around-the-lab/roles-expectations.md
@@ -30,9 +30,6 @@ Therefore, membership in the NDCLab is a team effort and all members are expecte
 **Dress Code**<br/>
 Members of the NDCLab interact not only with one another, but also with members of the greater FIU community and with the adolescents and families supported by the Center for Children and Families. Business casual attire is expected when representing the lab, whether in-person or via remote teleconferencing. In practice, this means dressing as you would to a job interview, avoiding the exposure of too much bare skin, offensive logos, etc. If you are uncertain as to what constitutes appropriate attire, reach out to the lab manager for additional guidance.
 
-**Data Security**<br/>
-Data security is of utmost importance. All members of the NDCLab are expected to install, and maintain up-to-date, an appropriate antivirus program on their computer prior to connecting the the FIU HPC.
-
 ## What to Expect from the Lab Director
 **Lab Level**<br/>
 The lab director commits to:

--- a/docs/around-the-lab/taking-time.md
+++ b/docs/around-the-lab/taking-time.md
@@ -2,7 +2,7 @@
 layout: default
 title: Taking Time Away
 parent: Around the Lab
-nav_order: 4
+nav_order: 5
 ---
 
 


### PR DESCRIPTION
@georgebuzzell

Here is another admin PR for you. Arina had some trouble finding the video for the meeting she had missed, so (in addition to making a modification to how I handle that within Slack), I also wanted to add some information for new members on where to find agenda, meeting notes, and the video link.

At the same time, I reviewed your changes yesterday and corrected a few typos. :)  I also deleted the antivirus section from roles/expectations since I will now be handling that during onboarding.