### PR TITLE
Add REDCap alt name

### DIFF
--- a/docs/etiquette/naming-conventions.md
+++ b/docs/etiquette/naming-conventions.md
@@ -213,6 +213,11 @@ In the above, "X" is replaced by a numerical value (1, 2, 3) to indicate the ord
 | initState_s1_r2_e2 | gathered during the initial 2021 session with the participant and as part of the second part of the study, and **after** the experimental manipulation |
 | initState_s2_r1_e1 | gathered during a follow-up session in 2023 with the participant and as part of the first part of that follow-up study |
 
+_Note_: When using a zip file to import an existing instrument to REDCap, the instrument name is displayed as:
+>Instrument SX RX EX
+
+This is also an acceptable format as data exported from REDCap automatically converts this to `instrument_sX_rX_eX`.
+
 ### Variable Names
 
 #### Scored Instruments


### PR DESCRIPTION
@georgebuzzell @anaNDClab @F-said @SDOsmany 

This PR addresses a minor nomenclature issue that I discovered when testing REDCap import/export options.  Please let me know if you have any concerns about allowing this variability to enable users to avoid manually renaming imported instruments within REDCap that will be s1_r1_e1.

Basically, if you export an instrument named `instrument_s1_r1_e1` from REDCap, when you re-import that same instrument (for example, to use on a different study), REDCap automatically displays this name as "Instrument S1 R1 E1".  However, this is just a display within the REDCap interface and any csv file exported from REDCap uses the expected value of `instrument_s1_r1_e1` in the naming of the instrument start/stop columns. The automatic scoring infrastructure relies on those start/stop columns.  Therefore, I believe that we would **not** want people to be forced to rename the instruments to "instrument_s1_r1_e1" within the REDCap display if they were using session 1 , run 1, and event 1 as it effectively creates an opportunity for manual error that otherwise would not exist.