### PR TITLE
Relax dev/main rules for datasets and analyses

### DIFF
--- a/docs/etiquette/github-etiquette.md
+++ b/docs/etiquette/github-etiquette.md
@@ -72,7 +72,6 @@ Almost all projects will involve more than one epic/release. This is to provide 
 
 At the start of a project, all planned epic/release goals for a project should be explicitly stated in the `readme` file on the project's GitHub repository. Each planned epic/release should be established as a time-blocked "Epic" within ZenHub.
 
-An epic/release is considered complete when the improvement (be that a new version of a tool or a publication of some type) is pushed to the `main` branch of the project repository on GitHub.
 
 ### Issues (1-3 weeks)
 
@@ -146,26 +145,33 @@ Pending the venue, project status, and other particulars, this may be a very inf
 
 ## Opening a New Project
 
-New projects should be based on the NDCLab templates. Visit [this page](https://ndclab.github.io/wiki/docs/etiquette/github-templates.html) for details.
+New projects should be based on the NDCLab templates. Visit [this page](https://ndclab.github.io/wiki/docs/etiquette/github-templates.html) for details.  Once a project is opened, its `main` branch is consistently mirrored to the HPC. (Note: the `sourcedata/` and `derivatives/` folders are excluded from this mirroring for data security purposes.)
 
-The `main` branch is reserved for "published" information, such as pre-registrations, posters, publications, and official releases of validated software tools.
 
-The `dev` branch reflects the most up-to-date version of the current release.
+## Managing a Project
 
-Since all work will eventually be merged onto `dev` (before an ultimate merge onto `main`), all new branches should be created by branching off `dev`. More information is available on the [naming conventions page](https://ndclab.github.io/wiki/docs/etiquette/naming-conventions.html#github).
+All projects have both a `main` and a `dev` branch. The `main` branch should always be updated via a pull request from the `dev` branch. The project lead(s), lab director, lab manager, and lab technician have merge authority on any given project.
+
+Since all work will eventually be merged onto `dev` (before an ultimate merge onto `main`), all new branches should be created by branching off `dev`. More information is available on the [naming conventions page](https://ndclab.github.io/wiki/docs/etiquette/naming-conventions.html#github).  The project lead has the authority to make changes directly on the `dev` branch, but thoughtful branching is recommended when multiple team members are invovled in updating GitHub content for a project.
+
+It will be necessary to update the `main` branch regularly to ensure that working files are available on the HPC and to promote a positive public image of the project for any visitors to the lab's GitHub space. Project leads should use their discretion on when they can push updates to `main` themselves and when they should request a review (via a pull request) from another lab member, the lab manager, or the lab director. The consistent use of pull requests is strongly encouraged whenever feasible.
+
+For projects that involve building a lab tool, the standard git workflow is required: team members must submit changes to `dev` via a pull request from their own feature branch.
 
 
 ## Publishing a Release
 
-At certain stages of each project, information will be ready for public consumption. Since the NDCLab is an open lab, all of our work-in-progress is publicly available. However, we make a clear distinction to show visitors from outside our lab what we consider "done" by pushing this content to the `main` branch.
+At certain stages of each project, information will be ready for public consumption. Since the NDCLab is an open lab, all of our work-in-progress is publicly available. Therefore, a release is more of a symbolic gesture in the GitHub workflow and serves as an opportunity to make sure that the repository is looking sharp.
 
 To "publish" a release on GitHub:
 
-1. The project lead(s) should ensure that the `dev` branch is fully ready to deploy. This means that all content that is being "published" is well-organized and independently verified. (It is ok that some parts of future releases may still be in-progress.)
+1. Make sure that all content in `main` and `dev` are tidy. (It is ok that some parts of future releases may still be in-progress.)
 
-2. The project lead(s) initiate a pull request, tagging the lab director for a level 2 review. He may review personally or delegate the review.
+2. Make sure that the lab director has approved the release. This can be accomplished via a final pull request to `main`, but it can also be accomplished via direct communication.
 
-Once `dev` is merged to `main`, this completes the current epic/release. The ZenHub *Release Backlog*, *Sprint Backlog*, *In Progress*, *Review/QA*, and *Done* pipelines should all be empty and all the issues that were tackled during the epic/release should be closed. The next epic/release is initiated by moving the Epic tile for the next planned epic/release and its associated issues into the Release Backlog.
+3. Notify the lab and celebrate the achievement!
+
+The publication of a release should match the completion of an epic/release. The ZenHub *Release Backlog*, *Sprint Backlog*, *In Progress*, *Review/QA*, and *Done* pipelines should all be empty and all the issues that were tackled during the epic/release should be closed. The next epic/release is initiated by moving the Epic tile for the next planned epic/release and its associated issues into the Release Backlog.
 
 
 ## Correcting Data
@@ -180,6 +186,7 @@ If your analysis is potentially impacted by the error:
 ## Communication
 
 * Watch your notifications so that you respond in a timely manner when someone @mentions you or asks you to review a pull request.
+* If you have been tagged in a pull request comment, assigned as a "reviewer," or simply assigned to the pull request directly: you are responsible for reviewing and responding to the requestor.
 * When assigning someone to an issue, include an explanatory comment (with @mention) to explain why you think the person is a good fit for the task -- don't just randomly assign people issues without dialogue.
 * Use the "question" and "help wanted" labels to communicate to the broader team that you are stuck and need assistance.
 

--- a/docs/etiquette/github-templates.md
+++ b/docs/etiquette/github-templates.md
@@ -41,25 +41,6 @@ Be sure to tell the lab manager:
 * a pithy description of the project that will appear on the main lab GitHub page
 * who will be leading the project and who will be part of the initial project team (so that everyone gets the correct access level on the new repository)
 
-#### Prepare your new repo for use.
-
-Before you begin using your new repository, there are several settings that need to be implemented:
-
-##### 1. Create `dev` branch.
-Create a new branch named `dev` off the basis of the `main` branch. This is identical to how you created your own branch for updating the wiki who's-who page with your own information when you were [onboarded to GitHub](https://ndclab.github.io/wiki/docs/Onboarding/get-with-git.html).
-
-##### 2. Add branch protection rules to `main` and `dev` branches.
-
-Inside your repository on GitHub, click the 'Settings' button and select 'Branches' from the left-hand menu. You will need to "Add rule" twice, once for `dev` and once for `main`. In both cases, select "Require pull request reviews before merging" and set the number of required approving reviews at "1." Once complete, your branch protection rules should look like this:
-
-![gh_branch-protection](https://raw.githubusercontent.com/NDCLab/wiki/main/docs/_assets/technical/gh_branch-protection.png)
-
-These branch protection rules ensure that content must undergo a review before any branch is merged into `dev` or `main`.
-
-##### 3. Automatically delete head branches
-
-You will want to [check this option in your repository settings](https://docs.github.com/en/github/administering-a-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches) so that, when you review and merge the work of team members into `dev`, GitHub automatically deletes the branch they were working on (which has now been merged). This keeps your branch tree tidy. Don't worry: the branch protection rules you set up above prevent `dev` from being automatically deleted when it gets merged to `main`.
-
 #### Draft the `readme` file.
 
 Within the `dev` branch, draft the `readme.md` file that guides the development of your project.
@@ -72,7 +53,7 @@ Every repository should have a succinct `readme.md` file that serves as a roadma
 
 The template repository used to create your new project repo contains a template `readme.md` file that will guide you through the initial process of drafting the readme.
 
-As the project progresses, the readme must be updated to include information for any content included on the `main` branch, such as pre-registrations, conference posters, or working software releases.
+As the project progresses, the readme should be updated to include information for any content releases, such as pre-registrations, conference posters, or working software releases.
 
 #### Draft the `contributing` file.
 
@@ -82,9 +63,7 @@ At this initial setup stage, the `main` branch will be empty (except for the fil
 
 #### Request the launch review.
 
-Once you are satisfied with the `readme` and `contributing` files, initiate a pull request. Tag both the lab director and the lab manager.
-* The lab director will perform a [level 2 review](https://ndclab.github.io/wiki/docs/etiquette/github-etiquette.html#terminology) (or delegate such a review to another appropriate lab member) to approve your planned roadmap and merge `readme.md` and `contributing.md` to `main`.
-* The lab manager will confirm that your repository is set up with all the correct settings to ensure a smooth project launch.
+Once you are satisfied with the `readme` and `contributing` files, initiate a pull request. Tag the lab manager, who will confirm that your repository is in good order and ready for the lab director's review.  Once you have the green-light from the lab manager, assign teh pull request to the lab director, who will perform a [level 2 review](https://ndclab.github.io/wiki/docs/etiquette/github-etiquette.html#terminology) (or delegate such a review to another appropriate lab member) to approve your planned roadmap and merge `readme.md` and `contributing.md` to `main`.
 
 ### ZenHub
 


### PR DESCRIPTION
## Changes Made
**GitHub Etiquette**: relaxing of gitflow rules for datasets and analyses, enabling project leads to push to dev and main.
**GitHub Templates**: relaxing of gitflow rules for datasets and analyses, enabling project leads to push to dev and main.


## Checklist
- [x] All my proposed changes have been pushed to the remote.
- [x] This pull request is showing as a merge into `main`.
- [x] I have assigned a specific reviewer for this pull request.
- [x] I have connected any associated issues to this pull request so they will be automatically closed when the PR is merged.

## Notes
Please feel free to add comments for further updates to be integrated before merging to `main`!
